### PR TITLE
fix: removing nr1-metrics-aggregator submodule to resubmit PR correctly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,6 +52,3 @@
 [submodule "apps/nr1-observability-maps"]
 	path = apps/nr1-observability-maps
 	url = https://github.com/newrelic/nr1-observability-maps.git
-[submodule "apps/nr1-metrics-aggregator"]
-	path = apps/nr1-metrics-aggregator
-	url = https://github.com/newrelic/nr1-metrics-aggregator.git


### PR DESCRIPTION
Prematurely merged the original PR (https://github.com/newrelic/nr1-catalog/pull/33). This PR will _remove_ the `nr1-metrics-aggregator` submodule so it can be PR'ed to the catalog correctly.