### PR TITLE
feat: add nr1-victory-visualizations to nr1-catalog

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,6 +73,6 @@
 [submodule "apps/nr1-pathpoint"]
 	path = apps/nr1-pathpoint
 	url = https://github.com/newrelic/nr1-pathpoint
-[submodule "nr1-victory-visualizations"]
-	path = nr1-victory-visualizations
+[submodule "apps/nr1-victory-visualizations"]
+	path = apps/nr1-victory-visualizations
 	url = https://github.com/newrelic/nr1-victory-visualizations.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -73,6 +73,6 @@
 [submodule "apps/nr1-pathpoint"]
 	path = apps/nr1-pathpoint
 	url = https://github.com/newrelic/nr1-pathpoint
-[submodule "apps/nr1-victory-visualizations"]
-	path = apps/nr1-victory-visualizations
+[submodule "nr1-victory-visualizations"]
+	path = nr1-victory-visualizations
 	url = https://github.com/newrelic/nr1-victory-visualizations.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "apps/nr1-pathpoint"]
 	path = apps/nr1-pathpoint
 	url = https://github.com/newrelic/nr1-pathpoint
+[submodule "apps/nr1-victory-visualizations"]
+	path = apps/nr1-victory-visualizations
+	url = https://github.com/newrelic/nr1-victory-visualizations.git

--- a/globals.json
+++ b/globals.json
@@ -26,6 +26,5 @@
   "nr1-alerts-los-migrator": "6e48950e-bb5b-4c65-a3c3-045d83b4df46",
   "nr1-tag-improver": "d5b8c492-0f3e-4686-8539-0ba2fc35ad1a",
   "nr1-quickstarts": "cd2fc286-eb15-443a-a09f-f08b5993796d",
-  "nr1-pathpoint": "e98a1499-194a-4f47-a5bc-ae89887c9c3f",
-  "nr1-victory-visualizations": "a658a79f-192c-4635-9cbb-8b6f96818d07"
+  "nr1-pathpoint": "e98a1499-194a-4f47-a5bc-ae89887c9c3f"
 }

--- a/versions.json
+++ b/versions.json
@@ -25,5 +25,5 @@
   "nr1-alerts-los-migrator": "1.2.5",
   "nr1-tag-improver": "1.1.2",
   "nr1-quickstarts": "1.4.1",
-  "nr1-pathpoint": "1.0.1",
+  "nr1-pathpoint": "1.0.1"
 }

--- a/versions.json
+++ b/versions.json
@@ -26,5 +26,4 @@
   "nr1-tag-improver": "1.1.2",
   "nr1-quickstarts": "1.4.1",
   "nr1-pathpoint": "1.0.1",
-  "nr1-victory-visualizations": "1.0.8"
 }


### PR DESCRIPTION
## PR checklist to add a new application to the New Relic One Catalog

## [Nerdpack Approver](#nerdpack-approver)

- Provide the **GitHub handle** for the final Approver of this Nerdpack in your Pull Request. *Note: this is the person who will need to provide explicit sign off for the change ahead of deployment.*
- If known, what is the requested date for the deployment of this functionality? *Note: this information is regarded as a courtesy. Neither New Relic nor the **nr1-catalog maintainer team** are under any obligation to meet this request. It simply provides a useful target for completion.*

### [Functional Changes](#functional-changes)

List the functional changes in the pull request, highlighting the major features of the application.

- Three new custom visualizations available (stacked bar chart, circular progress bar, ect.) available to be added to dashboards

*Note: The rest of this template is a checklist and guide for ensuring that your pull request is swiftly and consistently approved.*

## [Project Naming Guidance](#project-naming-guidance)

- [x] Repo names and titles must not include the word `New Relic` or `newrelic`
- [x] Repo names and titles should be named with human-readable, functionally descriptive names
- [x] Repo names must be unique within the `nr1-catalog` repository to support the internal project mapping of submodules to uuid’s
- [ ] Project titles should use title case (e.g. “Deployment Analyzer”, not “Deployment analyzer”)
- [x] Projects must not include profanity or crude language in titles, repo names, or any documentation

## [Basic Nerdpack Validation](#basic-nerdpack-validation)

Validate that the following are present in your PR ahead of submitting:

- [x] Your application has been added as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to the nr1-catalog repo under the `apps` directory (i.e. `nr1-catalog/apps/YOUR_REPO` with an entry in the `.gitmodules` file)

**If adding a submodule**

```bash
# Assumed forked and cloned nr1-catalog repo
cd nr1-catalog/apps
git submodule add [YOUR REPO URL]
# example: git submodule add https://github.com/newrelic/nr1-browser-analyzer.git
git commit -a -m "feat: Adding [YOUR REPO NAME] to nr1-catalog."
```

**If updating a submodule to the latest commit**

```bash
# Assumed forked and cloned nr1-catalog repo
cd nr1-catalog/apps/[YOU REPO NAME]
git pull
cd ..
git commit -a -m "feat: Updating [YOUR REPO NAME] to v. [YOUR REPO VERSION]."
```

- [x] No other code in the `nr1-catalog` repo has been modified by your PR
- [x] the project contains only one Nerdpack with as many artifacts (launchers, nerdlets, etc.) as you choose

### [Features and Roadmap](#features-and-roadmap)

- [x] Does this application have a workflow and/or documentation within the UI for managing an empty state?

## [Repository setup](#repository-setup)

Your linked submodule repository must contain:

- [x] an `nr1.json` file in the root of your project [example here](https://github.com/newrelic/nr1-catalog/tree/master/examples/nr1.json) containing the following fields:
  - [x] `schemaType` with a value of `NERDPACK`
  - [x] `id` containing a uuid set by the nr1 CLI (i.e. `nr1 nerdpack:uuid -gf`)
  - [x] `displayName` containing the displayed name of the Nerdpack in the New Relic One Catalog (ex. `Browser Analyzer`)
  - [x] `description` containing the short description of the application's functionality
- [x] `icon.png` in the root of your project with the dimensions of **48x48**
- [x] a `package.json` ([example here](https://github.com/newrelic/nr1-catalog/tree/master/examples/package.json)) that contains:
  - [x] a `version` that follows [semantic versioning standards](website.link)
  - [x] a `scripts.eslint-check` command
  - [x] a `scripts.eslint-fix` command
- [x] a valid `LICENSE` file containing an approved permissive license (ex. Apache 2, MIT, BSD) ([example here](https://github.com/newrelic/nr1-catalog/tree/master/examples/LICENSE))

*Note: we do not permit projects that contain **any** [viral licensing](https://en.wikipedia.org/wiki/Viral_license) into the New Relic One Catalog.*

### [Catalog Metadata](#catalog-metadata)

Your project must contain a `catalog` directory with the following:

- [x] a `config.json` [see example](https://github.com/newrelic/nr1-catalog/tree/master/examples/catalog/config.json) containing the following fields:
  - [x] `tagline` brief headline for the application, **30** characters or less
  - [x] `repository` URL to the git repository, less than **1000** characters long
  - [x] `details` description of the usage and utility of the application, less than **1000** characters using carriage returns for formatting and no markdown or HTML markup
  - [x] `support` object containing:
    - [x] `issues` **valid URL** to the repositories issues list (generally the GitHub issues tab for the repo)
    - [x] `email` a **valid email address** of the team supporting the application (for New Relic, that generally takes the form of `opensource+<repo name>@newrelic.com`)
    - [x] `community` URL to a support thread, forum, or website for troubleshooting and usage support
  - [x] `whatsNew` a bulleted list of customer-facing changes in this version, less than **500** characters using carriage returns for formatting and no markdown or HTML markup

_Note: [Click here for a guide to capturing screenshots that adhere to the catalog requirements](./guides/capturing-screenshots)._

- [x] `screenshots` directory containing at most 6 image files that each comply with the following guidance:
  - [x] 3:2 aspect ratio
  - [x] .png format
  - [x] landscape orientation
  - [x] at least 1600px wide
- [x] `documentation.md` a markdown file  containing no HTML markup nor any markdown images ([example here](https://github.com/newrelic/nr1-catalog/tree/master/examples/catalog/documentation.md))
- [x] (optional) `additionalInfo.md` a markdown file  containing no HTML markup nor any markdown images ([example here](https://github.com/newrelic/nr1-catalog/tree/master/examples/catalog/additionalInfo.md))

## [Code Guidance](#code-guidance)

*The following are meant to highlight the types of common issues that can degraded performance for your application.*

- [x] The code does not violate the pinned versions of libraries for `react` and `react-dom` of **16.6.3** and `d3` of **3.5.17**
- [x] The code does not contain hard-coded New Relic account ids, user ids, or other identifiers that should be retrieved via the NR1 API based on the user viewing the nerdpack
- [x] The code makes efficient use of the `PlatformStateContext` and `NerdletStateContext` (i.e. not wrapping the entire Nerdlet in a state context when it's not necessary)
- [x] The code avoids the use of `await` with React's `setState` method
- [x] The code handles the asynchronous nature of `setState` updates
- [x] The code does not perform imperative data fetching (ex. `NerdGraphQuery.query`) in the `render` method
- [x] Whenever appropriate, the code's React components extend `React.PureComponent` vs. `React.Component`
- [x] The code's React components that do extend `React.Component` implement the `shouldComponentUpdate` React lifecycle method

### [Design Guidance](#design-guidance)

- [x] The code does not override or amend core NR1 styles

### [Security Guidance](#security-guidance)

- [x] The code does not contain hard-coded API keys, access tokens, or other security credentials
- [x] The code does not include additional `SCRIPT` tags
- [x] The code avoids the use of the `eval` command
- [x] The code avoids the use of `Function` as a constructor (i.e. `new Function(...)`)
- [x] The code avoids the use of `dangerouslySetInnerHTML` in React
- [x] The code does not write data to an outside source
- [x] The code does not interact with an outside URL without clear documentation on what is being retrieved
- [x] The code does not write unspecified object data to `NerdStorage`

### [NerdStorage Guidance](#nerdstorage-guidance)

Where appropriate, the code follows the guidance regarding [NerdStorage limits and usage](https://developer.newrelic.com/build-tools/new-relic-one-applications/nerdstorage)

- [x] The code does not store New Relic credentials in `NerdStorage` (GraphQL should be used to access New Relic data)
- [x] The code does not store third-party SaaS credentials in `NerdStorage` **UNLESS** a warning about the lack of encryption at rest and possibility of access by New Relic employees is prominently displayed, such as in the GitHub README ([example here](https://github.com/newrelic/nr1-github/blob/master/README.md#using-github-personal-access-tokens)) and/or in documentation portion of the New Relic One Catalog documentation ([example here](https://github.com/newrelic/nr1-github/blob/master/catalog/documentation.md#using-github-personal-access-tokens))
- [x] The code does not store personal data ([PII](https://www.gdpreu.org/the-regulation/key-concepts/personal-data/)) in `NerdStorage`


## [New Relic only](#new-relic-only)

*Note: These concluding sections of instruction are for projects submitted by New Relic teams. If that doesn't apply to you, ignore this section in your PR.*

- [x] a standard `CONTRIBUTING.md` file in the root of the project ([example here](https://github.com/newrelic/nr1-catalog/tree/master/examples/CONTRIBUTING.md))
- [x] a standard `CODE_OF_CONDUCT.md` file in the root of the project ([example here](https://github.com/newrelic/nr1-catalog/tree/master/examples/CODE_OF_CONDUCT.md))
- [x] a standard `cla.md` file in the root of the project ([example here](https://github.com/newrelic/nr1-catalog/tree/master/examples/cla.md))
- [x] a `README.md` that contains:
  - [x] the [`New Relic One Catalog`](https://github.com/newrelic/open-source-office/blob/master/examples/categories/index.md#nr1-catalog) project header at the top of the file
  - [x] Description what the project does
  - [x] Explains cloning and setup of the code(including installing dependencies) for local development
  - [x] How run the nerdpack locally
- [x] your project makes use of New Relic's open source [eslint configuration](https://github.com/newrelic/eslint-plugin-newrelic) by including the following:
  - [x] include the appropriate development dependencies by running `npm install --save-dev @newrelic/eslint-plugin-newrelic eslint prettier` ([see example](https://github.com/newrelic/nr1-catalog/tree/master/examples/package.json))
  - [x] include the `.eslintrc.js` configuration in the root of your project [example here](https://github.com/newrelic/nr1-catalog/tree/master/examples/.eslintrc.js)
  - [x] include the `.prettierrc.js` configuration in the root of your project [example here](https://github.com/newrelic/nr1-catalog/tree/master/examples/.prettierrc.js)

### Additional Code Guidance for New Relic

*Note: this is for New Relic projects only.*

- [x] JavaScript in your nerdpack must use ES6
- [x] The code should make use of the NR1 components. Whenever possible, the code should avoid using an external OSS component in favor of highlighting the NR1 SDK's capabilities
- [x] The code should make use of the NR1 `Stack` and `Grid` components for layout, as these components respect spacing automatically (*Note that CSS flexbox and grid are more complex than what they seem at first and sometimes they’re a bit tricky to get exact results.*)