### PR TITLE
Update nr1-pathpoint to 1.5.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -25,7 +25,7 @@
   "nr1-alerts-los-migrator": "1.2.5",
   "nr1-tag-improver": "1.3.0",
   "nr1-quickstarts": "1.5.0",
-  "nr1-pathpoint": "1.1.1",
+  "nr1-pathpoint": "1.5.2",
   "nr1-victory-visualizations": "1.7.0",
   "nr1-status-widgets": "2.15.0",
   "nr1-kentik-network-monitoring": "1.4.0"


### PR DESCRIPTION
Want to upgrade NR1 catalog version of Pathpoint to 1.5.2.
Pathpoint is managed by @JimHagan (me) and a New Relic partner (Wigi Labs) handles most of the development.
Please let me know if this PR needs additional changes.