### PR TITLE
fix: Remove graphiql-notebook

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,9 +19,6 @@
 [submodule "apps/nr1-github"]
 	path = apps/nr1-github
 	url = https://github.com/newrelic/nr1-github.git
-[submodule "apps/nr1-graphiql-notebook"]
-	path = apps/nr1-graphiql-notebook
-	url = https://github.com/newrelic/nr1-graphiql-notebook.git
 [submodule "apps/nr1-groundskeeper"]
 	path = apps/nr1-groundskeeper
 	url = https://github.com/newrelic/nr1-groundskeeper.git

--- a/globals.json
+++ b/globals.json
@@ -7,7 +7,6 @@
   "nr1-event-stream": "4af0e16c-7082-48c0-9276-46c76f1e0747",
   "nr1-integrations-manager": "e9074d13-3fae-46e5-bffd-f271253649bf",
   "nr1-github": "4ee1cd5f-0f5e-4326-b153-5468c888ba8d",
-  "nr1-graphiql-notebook": "8432e742-6910-4957-b34f-c5115eb8cda3",
   "nr1-groundskeeper": "4a13b4e8-3129-467b-a099-ba5f503fe47f",
   "nr1-neon": "05b9a05f-7bc7-42af-a802-ddf50ae59c94",
   "nr1-network-telemetry": "57edc75e-339e-4703-a3d5-c253ad116e15",

--- a/versions.json
+++ b/versions.json
@@ -7,7 +7,6 @@
   "nr1-event-stream": "1.6.1",
   "nr1-integrations-manager": "1.10.1",
   "nr1-github": "0.9.2",
-  "nr1-graphiql-notebook": "0.7.0",
   "nr1-groundskeeper": "0.12.1",
   "nr1-neon": "0.7.1",
   "nr1-network-telemetry": "0.8.3",


### PR DESCRIPTION
Removing the graphiql-notebook submodule from the catalog

Closes https://github.com/newrelic/nr1-catalog/issues/313