### PR TITLE
chore(build): remove peer deps checks in workflows

### DIFF
--- a/.github/workflows/catalog-pr.yml
+++ b/.github/workflows/catalog-pr.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install Dependencies
         if: env.SUBMODULE_NAME != ''
         working-directory: ./${{ env.SUBMODULE_NAME }}
-        run: npm install
+        run: npm install --legacy-peer-deps --ignore-scripts
 
       - name: Install NR1 CLI
         if: env.SUBMODULE_NAME != ''
@@ -147,7 +147,7 @@ jobs:
       - name: Install Dependencies
         if: env.SUBMODULE_NAME != ''
         working-directory: ./${{ env.SUBMODULE_NAME }}
-        run: npm install
+        run: npm install --legacy-peer-deps --ignore-scripts
 
       - name: Run eslint-check
         if: env.SUBMODULE_NAME != ''
@@ -221,7 +221,7 @@ jobs:
       - name: Install Dependencies
         if: env.SUBMODULE_NAME != ''
         working-directory: ./${{ env.SUBMODULE_NAME }}
-        run: npm install
+        run: npm install --legacy-peer-deps --ignore-scripts
 
       - name: Run npm test
         if: env.SUBMODULE_NAME != ''
@@ -299,7 +299,7 @@ jobs:
           NODE_OPTIONS: --openssl-legacy-provider
         run: |
           cd ./.github/actions/files-present-action
-          npm install
+          npm install --legacy-peer-deps --ignore-scripts
           npm run build && npm run pack
 
       - name: files-present-action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install Dependencies
         if: env.SUBMODULE_NAME != ''
         working-directory: ./${{ env.SUBMODULE_NAME }}
-        run: npm install
+        run: npm install --legacy-peer-deps --ignore-scripts
 
       - name: Install NR1 CLI
         if: env.SUBMODULE_NAME != ''
@@ -163,7 +163,7 @@ jobs:
           NODE_OPTIONS: --openssl-legacy-provider
         run: |
           cd ./.github/actions/map-global-uuid
-          npm install
+          npm install --legacy-peer-deps --ignore-scripts
           npm run build && npm run pack
 
       - name: map-global-uuid
@@ -192,7 +192,7 @@ jobs:
           CURRENT_VERSION=$(node -p "require('./versions.json')['${NERDPACK:5}']")
 
           if [[ $SUBMODULE_VERSION != $CURRENT_VERSION ]]; then
-            npm install -g json
+            npm install --legacy-peer-deps --ignore-scripts -g json
             echo "Updating versions.json"
             json -I -f versions.json -e "this['${NERDPACK:5}']='$SUBMODULE_VERSION'"
             cat versions.json
@@ -221,7 +221,7 @@ jobs:
           NR1_REGION_STAGING: staging
         run: |
           cd ${{ env.SUBMODULE_NAME }}
-          npm install
+          npm install --legacy-peer-deps --ignore-scripts
 
           # US region was added previously when we installed the CLI, now add the other 2 profiles
           nr1 profiles:add --name nr1-apps-staging --api-key "$NR1_APPS_KEY_STAGING" --region "$NR1_REGION_STAGING"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,7 @@ jobs:
           CURRENT_VERSION=$(node -p "require('./versions.json')['${NERDPACK:5}']")
 
           if [[ $SUBMODULE_VERSION != $CURRENT_VERSION ]]; then
-            npm install --legacy-peer-deps --ignore-scripts -g json
+            npm install -g json
             echo "Updating versions.json"
             json -I -f versions.json -e "this['${NERDPACK:5}']='$SUBMODULE_VERSION'"
             cat versions.json


### PR DESCRIPTION
Adds the `--legacy-peer-deps` and `--ignore-scripts` flags to `npm install` in the `catalog-pr.yml` and `release.yml` workflows